### PR TITLE
Only accept plaintext files

### DIFF
--- a/src/PopulateFrontend/frontend-code/src/components/Form.js
+++ b/src/PopulateFrontend/frontend-code/src/components/Form.js
@@ -44,7 +44,7 @@ function Form (props) {
         <select name='targetLanguage' value={props.targetLanguage} onChange={props.onTargetLanguageChange}>
           { options }
         </select>
-        <input onChange={props.onFileChange} type='file' key={props.inputKey} />
+        <input onChange={props.onFileChange} accept=".txt" type='file' key={props.inputKey} />
         <button type='submit' className='submitButton'>Submit</button>
         <span className='messageText'>{props.message}</span>
       </form>


### PR DESCRIPTION
Currently, users can select any filetype. If they select one that's not plaintext, they get an error during upload. This PR utilizes the `accept` [attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#attr-accept) to only allow plaintext files.